### PR TITLE
Updated server URL

### DIFF
--- a/user-management-spec.json
+++ b/user-management-spec.json
@@ -16,6 +16,10 @@
     },
     "servers": [
         {
+            "url": "https://tdei-usermanagement-ts-stage.azurewebsites.net",
+            "description": "Staging"
+        },
+        {
             "url": "https://tdei-usermanagement-ts-dev.azurewebsites.net",
             "description": "Development"
         },


### PR DESCRIPTION
Updating the staging url in specification. 
The URL specification is missing the stage configuration. This fails to work on the swagger UI when hosted in stage.