### PR TITLE
Task 1714

### DIFF
--- a/src/assets/user-management-spec.json
+++ b/src/assets/user-management-spec.json
@@ -633,60 +633,8 @@
                     "User Management"
                 ],
                 "summary": "Associates a user with the project group and permissions in the TDEI system",
-                "description": "Associates a user with the project group and permissions in the TDEI system. Returns the boolean flag true.",
+                "description": "Associates a user with the project group and permissions in the TDEI system. Returns the boolean flag true. Empty permissions array will remove a user from Project Group.",
                 "operationId": "permission",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/RoleDetails"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful response - Returns the boolean flag true.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Response"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request."
-                    },
-                    "404": {
-                        "description": "User not found."
-                    },
-                    "500": {
-                        "description": "Internal server error."
-                    },
-                    "401": {
-                        "description": "Unauthenticated request"
-                    },
-                    "403": {
-                        "description": "Unauthorized request"
-                    }
-                },
-                "security": [
-                    {
-                        "AuthorizationToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v1/permission/revoke": {
-            "put": {
-                "tags": [
-                    "User Management"
-                ],
-                "summary": "Revokes the user permissions",
-                "description": "Revokes the user permissions.",
-                "operationId": "revokePermission",
                 "requestBody": {
                     "content": {
                         "application/json": {

--- a/src/controller/user-management-controller.ts
+++ b/src/controller/user-management-controller.ts
@@ -24,7 +24,7 @@ class UserManagementController implements IController {
     public intializeRoutes() {
         this.router.post(`${this.path}/api/v1/register`, validationMiddleware(RegisterUserDto), this.registerUser);
         this.router.post(`${this.path}/api/v1/permission`, authorizationMiddleware([Role.POC, Role.TDEI_ADMIN], true), validationMiddleware(RolesReqDto), this.updatePermissions);
-        this.router.put(`${this.path}/api/v1/permission/revoke`, authorizationMiddleware([Role.POC, Role.TDEI_ADMIN], true), validationMiddleware(RolesReqDto), this.revokePermissions);
+        // this.router.put(`${this.path}/api/v1/permission/revoke`, authorizationMiddleware([Role.POC, Role.TDEI_ADMIN], true), validationMiddleware(RolesReqDto), this.revokePermissions);
         this.router.get(`${this.path}/api/v1/roles`, authorizationMiddleware([Role.POC, Role.TDEI_ADMIN]), this.getRoles);
         this.router.get(`${this.path}/api/v1/project-group-roles/:userId`, authorizationMiddleware([], false, true), this.projectGroupRoles);
         this.router.post(`${this.path}/api/v1/authenticate`, validationMiddleware(LoginDto), this.login);

--- a/src/model/dto/roles-req-dto.ts
+++ b/src/model/dto/roles-req-dto.ts
@@ -1,7 +1,6 @@
-import { ArrayNotEmpty, IsArray, IsIn, IsNotEmpty, Length, MaxLength, Validate } from "class-validator";
+import { IsArray, IsNotEmpty, Length, MaxLength } from "class-validator";
 import { Prop } from "nodets-ms-core/lib/models";
 import { BaseDto } from "./base-dto";
-import { IsStringArrayLength } from "../../utility/utility";
 
 export class RolesReqDto extends BaseDto {
     @IsNotEmpty()


### PR DESCRIPTION
Task : https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1714

- Updated the open api spec for /permission api to removal of user from project group when requested with empty roles. 
- Removed unwanted /revoke api , which was required for removal of user from project group, which logic is now integrated in /permissions.
- /roles api will return "member" role in response.
- Added restriction to removal of permissions to allow only Admin to remove user from "Tdei Default" project group.
- Updated test cases