### PR TITLE
user profile endpoint issue with + character

### DIFF
--- a/src/controller/user-management-controller.ts
+++ b/src/controller/user-management-controller.ts
@@ -92,6 +92,10 @@ class UserManagementController implements IController {
             let user_name = request.query.user_name;
             if (user_name == undefined || user_name == null) throw new HttpException(400, "user_name query param missing");
 
+            const rawQuery = request.originalUrl.split("?")[1] || "";
+            const match = rawQuery.match(/user_name=([^&]*)/);
+            user_name = match ? match[1] : "";
+            user_name = decodeURIComponent(user_name);
             return userManagementServiceInstance.getUserProfile(user_name as string).then((result) => {
                 Ok(response, result);
             }).catch((error: any) => {

--- a/src/middleware/authorization-middleware.ts
+++ b/src/middleware/authorization-middleware.ts
@@ -12,6 +12,11 @@ function authorizationMiddleware(roles: string[], validateProjectGroup?: boolean
 
         let authToken = Utility.extractToken(req);
 
+        if (roles.length > 0 && authToken == null) {
+            next(new Forbidden());
+            return;
+        }
+
         if (authToken == null) {
 
             if (allowInraCom) {


### PR DESCRIPTION
## Bug Fix
###  DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1789

### Issue Summary  
- User name having with '+' sign,  when requests for user profile details , backend service gives 404 user not found. 
- Nodejs considered '+' sign as  special character and replaces with space, which is the reason system gives 404.

### Fix Implemented  
- Express request.query transforms '+' sign to space, so to avoiding the transform , we used raw query to extract the user_name and decodeURL 
- Fix can take encoded or decoded value and process both of them properly. 
- Ex . username=alex+dev@test.com or alex%2Bdev%40test.com
- Added extra check for early exit of function if no auth token. 

### Impacted Areas for Testing  
- Get user profile