### PR TITLE
handle registered user with promo

### DIFF
--- a/src/service/user-management-service.ts
+++ b/src/service/user-management-service.ts
@@ -103,11 +103,12 @@ export class UserManagementService implements IUserManagement {
      */
     async registerUser(user: RegisterUserDto): Promise<UserProfile> {
         let userProfile = new UserProfile();
+        let promo_code_exists = false;
         try {
             let referralCodeDetails: ReferralCodeDto | undefined = undefined;
             //Check if referral code is valid
             if (user.code && user.code.length > 0) {
-                //valid_to can be null for indefinite validity
+                promo_code_exists = true;
                 let referralCodeQuery = format('SELECT * FROM promo_referrals WHERE UPPER(code) = %L AND is_active = true AND valid_from <= NOW() AND (valid_to >= NOW() OR valid_to IS NULL) limit 1', user.code.toUpperCase());
 
                 const referralCodeResult = await dbClient.query(referralCodeQuery);
@@ -124,30 +125,46 @@ export class UserManagementService implements IUserManagement {
                 headers: { 'Content-Type': 'application/json' }
             });
 
-            if (result.status != undefined && result.status == 409)
-                throw new HttpException(409, "User already exists with email " + user.email);
-
-            if (result.status != undefined && result.status == 400) {
-                const data = await result.json();
-                throw new HttpException(400, `${data.message}, ${data.errors?.join(',')}`);
+            if (result.status === undefined) {
+                console.error("Invalid response from user registration service", result);
+                throw new Error("Error registering the user");
             }
 
-            if (result.status != undefined && result.status != 200)
-                throw new Error();
-
-            const data = await result.json();
-            userProfile = new UserProfile(data);
+            switch (result.status) {
+                case 200: {
+                    const data = await result.json();
+                    userProfile = new UserProfile(data);
+                    break;
+                }
+                case 400: {
+                    const data = await result.json();
+                    throw new HttpException(400, `${data.message}, ${data.errors?.join(',')}`);
+                }
+                case 409: {
+                    if (!promo_code_exists) {
+                        throw new HttpException(409, `User already exists with email ${user.email}`);
+                    } else {
+                        // Promo code exists, fetch user profile
+                        const data = await this.getUserProfile(user.email);
+                        userProfile = data;
+                    }
+                    break;
+                }
+                default: {
+                    throw new Error(`Error registering the user`);
+                }
+            }
 
             //If referral code is valid, then assign the user to the project group associated with referral code with TDEI member role
             //Else assign the user to default project group with TDEI member role
-            if (referralCodeDetails) {
+            if (promo_code_exists) {
                 const rolesDetails = await this.getRolesByNames([Role.TDEI_MEMBER]);
                 const role_id = rolesDetails.get(Role.TDEI_MEMBER);
-                let addRoleProjectQuery = format(`INSERT INTO user_roles (user_id, project_group_id, role_id) VALUES %L ON CONFLICT ON CONSTRAINT unq_user_role_project_group DO NOTHING`, [[userProfile.id, referralCodeDetails.project_group_id, role_id]]);
+                let addRoleProjectQuery = format(`INSERT INTO user_roles (user_id, project_group_id, role_id) VALUES %L ON CONFLICT ON CONSTRAINT unq_user_role_project_group DO NOTHING`, [[userProfile.id, referralCodeDetails!.project_group_id, role_id]]);
                 await dbClient.query(addRoleProjectQuery);
 
                 //Update the instructions url in the user profile if exists
-                userProfile.instructions_url = referralCodeDetails.instructions_url;
+                userProfile.instructions_url = referralCodeDetails!.instructions_url;
                 //Generate the auth token and assign refresh token to user profile
                 const loginDto = new LoginDto();
                 loginDto.username = user.email;

--- a/test/unit/user-management.service.test.ts
+++ b/test/unit/user-management.service.test.ts
@@ -233,7 +233,67 @@ describe("User Management Service Test", () => {
                 expect(getDbRoleByNamesSpy).toHaveBeenCalled();
             });
 
-            test("When user already exists with same email, Expect to throw error", async () => {
+            test("When registered user requested with promo code do not throw error, Expect to return user profile response on success with instruction url (optional) and token ", async () => {
+                //Arrange
+                let newuser = new RegisterUserDto({
+                    firstName: "firstname",
+                    lastName: "lastname",
+                    email: "email",
+                    phone: "phone",
+                    password: "password",
+                    code: "PROMO123"
+                });
+                //User already registered, so user service returns 409
+                fetchMock.mockResolvedValueOnce(Promise.resolve(<any>{
+                    status: 409
+                }));
+                //Fetch userprofile for the registered user
+                fetchMock.mockResolvedValueOnce(Promise.resolve(<any>{
+                    status: 200,
+                    json: () => Promise.resolve(<UserProfile>{
+                        firstName: "firstname",
+                        lastName: "lastname",
+                        email: "email",
+                        phone: "phone",
+                        id: "id",
+                        username: "email",
+                        emailVerified: true,
+                        apiKey: "apiKey",
+                        instructions_url: "http://example.com/instructions",
+                        token: "token"
+                    }),
+                }));
+                const referralCodeRow = {
+                    code: 'PROMO123',
+                    is_active: true,
+                    valid_from: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+                    valid_to: null,
+                    project_group_id: "pgid",
+                    instructions_url: "http://example.com/instructions"
+                };
+                const getDbPromoSpy = jest
+                    .spyOn(dbClient, "query")
+                    .mockResolvedValueOnce(<QueryResult>{ rows: [referralCodeRow] });
+                const getDbRoleByNamesSpy = jest
+                    .spyOn(dbClient, "query")
+                    .mockResolvedValueOnce(<QueryResult>{ rows: [{ role_id: 'role_id_1', name: Role.TDEI_MEMBER }] });
+                const getDbSpy = jest
+                    .spyOn(dbClient, "query")
+                    .mockResolvedValueOnce(<QueryResult>{});
+                const getLoginSpy = jest
+                    .spyOn(userManagementServiceInstance, "login")
+                    .mockResolvedValueOnce(<any>{ refresh_token: "refresh_token", access_token: "access_token" });
+                //Act
+                let result = await userManagementServiceInstance.registerUser(newuser);
+                //Assert
+                // expect(result.apiKey).toBe("apiKey");
+                expect(getDbPromoSpy).toHaveBeenCalled();
+                expect(getDbSpy).toHaveBeenCalled();
+                expect(getLoginSpy).toHaveBeenCalled();
+                expect(getDbRoleByNamesSpy).toHaveBeenCalled();
+            });
+
+            test("When registered user requests with promo code, Expect to throw error", async () => {
                 //Arrange
                 let newuser = new RegisterUserDto({
                     firstName: "firstname",


### PR DESCRIPTION
## DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2389

## Changes Introduced  
- Handled use case where registered user trying to scan same promo code again and registers , in this case user will not be thrown error instead will be responded with user profile details with token for deeplink navigation. 
- Handled use case where registered user trying to scan different promo code and registers, in this case user will be associated with new promo code project group and will be responded with user profile details with token for deeplink navigation. 
- Refactoring changes
- Added unit test case

## Impacted Areas for Testing  
- Test Registered user with same promo code
- Test Registered user with new promo code
